### PR TITLE
Feature: When editing Application in an existing rule, don't reset the other settings

### DIFF
--- a/TinyWall/ApplicationExceptionForm.cs
+++ b/TinyWall/ApplicationExceptionForm.cs
@@ -386,6 +386,15 @@ namespace pylorak.TinyWall
         private void ReinitFormFromSubject(ExceptionSubject subject)
         {
             List<FirewallExceptionV3> exceptions;
+            if (
+                (TmpExceptionSettings.Count >= 0)
+                && (TmpExceptionSettings[0].Subject.SubjectType != SubjectType.Invalid)
+                )
+            {
+                exceptions = TmpExceptionSettings;
+                exceptions[0].Subject = subject;
+            }
+            else
             {
                 exceptions = GlobalInstances.AppDatabase.GetExceptionsForApp(subject, true, out _);
                 if (exceptions.Count == 0)

--- a/TinyWall/ApplicationExceptionForm.cs
+++ b/TinyWall/ApplicationExceptionForm.cs
@@ -385,9 +385,12 @@ namespace pylorak.TinyWall
 
         private void ReinitFormFromSubject(ExceptionSubject subject)
         {
-            List<FirewallExceptionV3> exceptions = GlobalInstances.AppDatabase.GetExceptionsForApp(subject, true, out _);
-            if (exceptions.Count == 0)
-                return;
+            List<FirewallExceptionV3> exceptions;
+            {
+                exceptions = GlobalInstances.AppDatabase.GetExceptionsForApp(subject, true, out _);
+                if (exceptions.Count == 0)
+                    return;
+            }
 
             TmpExceptionSettings = exceptions;
 


### PR DESCRIPTION
This modifies the behavior of the `Select a process...`, `Browse for a file...`, `Choose a service...` and `Pick a UWP app...` buttons in the rule editor so that they don't reset the settings of the existing rule. The original behavior was fine for setting up a new rule, as it would populate it from the presets for known applications, but it's quite undesirable for editing rules as the change of the application would drop all of the other settings. Unfortunately, there are applications where the path changes with every update (e.g. Microsoft Edge WebView), forcing a modification of the firewall rule - but there isn't really any reason to change the allowed ports.