### PR TITLE
Fix remaining native memory leaks (WFP events, bitmap, WMI watcher)

### DIFF
--- a/TinyWall/AsyncIconScanner.cs
+++ b/TinyWall/AsyncIconScanner.cs
@@ -46,9 +46,17 @@ namespace pylorak.TinyWall
                         {
                             listView.BeginInvoke((MethodInvoker)delegate
                             {
+                                if (listView.IsDisposed)
+                                {
+                                    icon?.Dispose();
+                                    return;
+                                }
+
                                 if (is_icon_new)
                                 {
                                     imageList.Images.Add(icon_path, icon);
+                                    _ = imageList.Handle;  // Ensure native HIMAGELIST has independent copy
+                                    icon?.Dispose();  // Safe: managed HBITMAP freed, native copy unaffected
                                     icon_idx = imageList.Images.IndexOfKey(icon_path);
                                     LoadedIcons.TryAdd(icon_path, icon_idx);
                                 }
@@ -64,7 +72,7 @@ namespace pylorak.TinyWall
                         }
                     }
                 }
-                listView.BeginInvoke((MethodInvoker)delegate { listView.Refresh(); });
+                listView.BeginInvoke((MethodInvoker)delegate { if (!listView.IsDisposed) listView.Refresh(); });
             });
         }
 

--- a/TinyWall/TinyWallService.cs
+++ b/TinyWall/TinyWallService.cs
@@ -1695,11 +1695,7 @@ namespace pylorak.TinyWall
             using var MountPointsWatcher = new RegistryWatcher(@"HKEY_LOCAL_MACHINE\SYSTEM\MountedDevices", true);
 
             WfpEngine.CollectNetEvents = true;
-            // Clear BCAST/MCAST keywords that may persist from a previous version.
-            // The callback (WfpNetEventCallback) only processes CLASSIFY_DROP and
-            // CLASSIFY_ALLOW; broadcast/multicast events were pure overhead and a
-            // suspected source of RPC buffer accumulation (see microsoft/Windows-classic-samples #202, #322).
-            WfpEngine.EventMatchAnyKeywords = InboundEventMatchKeyword.None;
+            WfpEngine.EventMatchAnyKeywords = InboundEventMatchKeyword.FWPM_NET_EVENT_KEYWORD_INBOUND_BCAST | InboundEventMatchKeyword.FWPM_NET_EVENT_KEYWORD_INBOUND_MCAST;
 
             ProcessStartWatcher.EventArrived += ProcessStartWatcher_EventArrived;
             NetworkInterfaceWatcher.InterfaceChanged += (object sender, EventArgs args) =>

--- a/TinyWall/TinyWallService.cs
+++ b/TinyWall/TinyWallService.cs
@@ -1571,35 +1571,32 @@ namespace pylorak.TinyWall
             var newLocalSubnetAddreses = new HashSet<IpAddrMask>();
             var newGatewayAddresses = new HashSet<IpAddrMask>();
             var newDnsAddresses = new HashSet<IpAddrMask>();
-            var coll = NetworkInterface.GetAllNetworkInterfaces();
-
-            foreach (var iface in coll)
+            // Use direct P/Invoke to GetAdaptersAddresses instead of
+            // NetworkInterface.GetAllNetworkInterfaces() to avoid native memory leak
+            // in iphlpapi!GetPerAdapterInfo -> DNSAPI!Dns_AllocZero (~15KB per call).
+            if (!NetworkAdapterEnumerator.EnumerateActiveAdapters(
+                out var unicastList, out var gatewayList, out var dnsList))
             {
-                if (iface.OperationalStatus != OperationalStatus.Up)
+                return false;
+            }
+
+            foreach (var entry in unicastList)
+            {
+                var am = new IpAddrMask(entry.Address, entry.PrefixLength);
+                if (am.IsLoopback || am.IsLinkLocal)
                     continue;
 
-                var props = iface.GetIPProperties();
+                newLocalSubnetAddreses.Add(am.Subnet);
+            }
 
-                foreach (var uni in props.UnicastAddresses)
-                {
-                    var am = new IpAddrMask(uni);
-                    if (am.IsLoopback || am.IsLinkLocal)
-                        continue;
+            foreach (var addr in gatewayList)
+            {
+                newGatewayAddresses.Add(new IpAddrMask(addr));
+            }
 
-                    newLocalSubnetAddreses.Add(am.Subnet);
-                }
-
-                foreach (var uni in props.GatewayAddresses)
-                {
-                    var am = new IpAddrMask(uni);
-                    newGatewayAddresses.Add(am);
-                }
-
-                foreach (var uni in props.DnsAddresses)
-                {
-                    var am = new IpAddrMask(uni);
-                    newDnsAddresses.Add(am);
-                }
+            foreach (var addr in dnsList)
+            {
+                newDnsAddresses.Add(new IpAddrMask(addr));
             }
 
             newLocalSubnetAddreses.Add(new IpAddrMask(IPAddress.Parse("255.255.255.255")));

--- a/TinyWall/TinyWallService.cs
+++ b/TinyWall/TinyWallService.cs
@@ -1695,7 +1695,11 @@ namespace pylorak.TinyWall
             using var MountPointsWatcher = new RegistryWatcher(@"HKEY_LOCAL_MACHINE\SYSTEM\MountedDevices", true);
 
             WfpEngine.CollectNetEvents = true;
-            WfpEngine.EventMatchAnyKeywords = InboundEventMatchKeyword.FWPM_NET_EVENT_KEYWORD_INBOUND_BCAST | InboundEventMatchKeyword.FWPM_NET_EVENT_KEYWORD_INBOUND_MCAST;
+            // Clear BCAST/MCAST keywords that may persist from a previous version.
+            // The callback (WfpNetEventCallback) only processes CLASSIFY_DROP and
+            // CLASSIFY_ALLOW; broadcast/multicast events were pure overhead and a
+            // suspected source of RPC buffer accumulation (see microsoft/Windows-classic-samples #202, #322).
+            WfpEngine.EventMatchAnyKeywords = InboundEventMatchKeyword.None;
 
             ProcessStartWatcher.EventArrived += ProcessStartWatcher_EventArrived;
             NetworkInterfaceWatcher.InterfaceChanged += (object sender, EventArgs args) =>
@@ -1964,6 +1968,7 @@ namespace pylorak.TinyWall
 
             FirewallThreadThrottler?.Dispose();
             Q.Dispose();
+            try { WfpEngine.CollectNetEvents = false; } catch { }  // Persistent across reboots - must reset
             WfpEngine.Dispose();
 
 #if !DEBUG

--- a/TinyWall/TinyWallService.cs
+++ b/TinyWall/TinyWallService.cs
@@ -1946,6 +1946,8 @@ namespace pylorak.TinyWall
         {
             using var timer = new HierarchicalStopwatch("TinyWallService.Dispose()");
             ServerPipe?.Dispose();
+            ProcessStartWatcher.EventArrived -= ProcessStartWatcher_EventArrived;
+            try { ProcessStartWatcher.Stop(); } catch { }
             ProcessStartWatcher.Dispose();
 
             if (MinuteTimer != null)

--- a/pylorak.Windows/NetworkAdapterEnumerator.cs
+++ b/pylorak.Windows/NetworkAdapterEnumerator.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Runtime.InteropServices;
+
+namespace pylorak.Windows
+{
+    /// <summary>
+    /// Direct P/Invoke wrapper for GetAdaptersAddresses.
+    /// Replaces NetworkInterface.GetAllNetworkInterfaces() which leaks ~15KB of
+    /// native memory per call through iphlpapi!GetPerAdapterInfo -> DNSAPI!Dns_AllocZero.
+    /// See: Unity issue UUM-52888, dotnet/runtime#50323.
+    /// </summary>
+    public static class NetworkAdapterEnumerator
+    {
+        [DllImport("iphlpapi.dll")]
+        private static extern uint GetAdaptersAddresses(
+            uint Family, uint Flags, IntPtr Reserved,
+            IntPtr AdapterAddresses, ref uint SizePointer);
+
+        private const uint AF_UNSPEC = 0;
+        private const uint GAA_FLAG_INCLUDE_GATEWAYS = 0x0080;
+        private const uint ERROR_BUFFER_OVERFLOW = 111;
+        private const uint ERROR_NO_DATA = 232;
+        private const uint ERROR_SUCCESS = 0;
+        private const int IF_OPER_STATUS_UP = 1;
+        private const short FAMILY_INET = 2;
+        private const short FAMILY_INET6 = 23;
+
+        #region Native structs - layout computed by CLR, no manual offsets
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SOCKET_ADDRESS
+        {
+            public IntPtr lpSockaddr;
+            public int iSockaddrLength;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct IP_ADAPTER_ADDRESSES
+        {
+            public ulong Alignment;
+            public IntPtr Next;
+            public IntPtr AdapterName;
+            public IntPtr FirstUnicastAddress;
+            public IntPtr FirstAnycastAddress;
+            public IntPtr FirstMulticastAddress;
+            public IntPtr FirstDnsServerAddress;
+            public IntPtr DnsSuffix;
+            public IntPtr Description;
+            public IntPtr FriendlyName;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
+            public byte[] PhysicalAddress;
+            public uint PhysicalAddressLength;
+            public uint Flags;
+            public uint Mtu;
+            public uint IfType;
+            public int OperStatus;
+            public uint Ipv6IfIndex;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+            public uint[] ZoneIndices;
+            public IntPtr FirstPrefix;
+            public ulong TransmitLinkSpeed;
+            public ulong ReceiveLinkSpeed;
+            public IntPtr FirstWinsServerAddress;
+            public IntPtr FirstGatewayAddress;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct IP_ADAPTER_UNICAST_ADDRESS
+        {
+            public ulong Alignment;
+            public IntPtr Next;
+            public SOCKET_ADDRESS Address;
+            public int PrefixOrigin;
+            public int SuffixOrigin;
+            public int DadState;
+            public uint ValidLifetime;
+            public uint PreferredLifetime;
+            public uint LeaseLifetime;
+            public byte OnLinkPrefixLength;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct IP_ADAPTER_LINKED_ADDRESS
+        {
+            public ulong Alignment;
+            public IntPtr Next;
+            public SOCKET_ADDRESS Address;
+        }
+
+        #endregion
+
+        public struct UnicastEntry
+        {
+            public IPAddress Address;
+            public int PrefixLength;
+        }
+
+        public static bool EnumerateActiveAdapters(
+            out List<UnicastEntry> unicastAddresses,
+            out List<IPAddress> gatewayAddresses,
+            out List<IPAddress> dnsAddresses)
+        {
+            unicastAddresses = new List<UnicastEntry>();
+            gatewayAddresses = new List<IPAddress>();
+            dnsAddresses = new List<IPAddress>();
+
+            uint size = 0;
+            uint result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_GATEWAYS, IntPtr.Zero, IntPtr.Zero, ref size);
+            if (result == ERROR_NO_DATA)
+                return true;
+            if (result != ERROR_BUFFER_OVERFLOW)
+                return false;
+
+            IntPtr buffer = IntPtr.Zero;
+            try
+            {
+                buffer = Marshal.AllocHGlobal((int)size);
+                result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_GATEWAYS, IntPtr.Zero, buffer, ref size);
+                if (result == ERROR_BUFFER_OVERFLOW)
+                {
+                    Marshal.FreeHGlobal(buffer);
+                    buffer = IntPtr.Zero;
+                    buffer = Marshal.AllocHGlobal((int)size);
+                    result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_GATEWAYS, IntPtr.Zero, buffer, ref size);
+                }
+                if (result != ERROR_SUCCESS)
+                    return false;
+
+                IntPtr adapterPtr = buffer;
+                while (adapterPtr != IntPtr.Zero)
+                {
+                    var adapter = (IP_ADAPTER_ADDRESSES)Marshal.PtrToStructure(adapterPtr, typeof(IP_ADAPTER_ADDRESSES));
+
+                    if (adapter.OperStatus == IF_OPER_STATUS_UP)
+                    {
+                        ReadUnicastAddresses(adapter.FirstUnicastAddress, unicastAddresses);
+                        ReadLinkedAddresses(adapter.FirstGatewayAddress, gatewayAddresses);
+                        ReadLinkedAddresses(adapter.FirstDnsServerAddress, dnsAddresses);
+                    }
+
+                    adapterPtr = adapter.Next;
+                }
+
+                return true;
+            }
+            finally
+            {
+                if (buffer != IntPtr.Zero)
+                    Marshal.FreeHGlobal(buffer);
+            }
+        }
+
+        private static void ReadUnicastAddresses(IntPtr ptr, List<UnicastEntry> result)
+        {
+            while (ptr != IntPtr.Zero)
+            {
+                var uni = (IP_ADAPTER_UNICAST_ADDRESS)Marshal.PtrToStructure(ptr, typeof(IP_ADAPTER_UNICAST_ADDRESS));
+                var ip = ReadIPAddress(uni.Address.lpSockaddr);
+                if (ip != null)
+                {
+                    result.Add(new UnicastEntry
+                    {
+                        Address = ip,
+                        PrefixLength = uni.OnLinkPrefixLength
+                    });
+                }
+                ptr = uni.Next;
+            }
+        }
+
+        private static void ReadLinkedAddresses(IntPtr ptr, List<IPAddress> result)
+        {
+            while (ptr != IntPtr.Zero)
+            {
+                var entry = (IP_ADAPTER_LINKED_ADDRESS)Marshal.PtrToStructure(ptr, typeof(IP_ADAPTER_LINKED_ADDRESS));
+                var ip = ReadIPAddress(entry.Address.lpSockaddr);
+                if (ip != null)
+                    result.Add(ip);
+                ptr = entry.Next;
+            }
+        }
+
+        private static IPAddress ReadIPAddress(IntPtr sockAddrPtr)
+        {
+            if (sockAddrPtr == IntPtr.Zero)
+                return null;
+
+            short family = Marshal.ReadInt16(sockAddrPtr, 0);
+
+            if (family == FAMILY_INET)
+            {
+                // sockaddr_in: family(2) + port(2) + addr(4)
+                var addr = new byte[4];
+                Marshal.Copy(IntPtr.Add(sockAddrPtr, 4), addr, 0, 4);
+                return new IPAddress(addr);
+            }
+
+            if (family == FAMILY_INET6)
+            {
+                // sockaddr_in6: family(2) + port(2) + flowinfo(4) + addr(16) + scope_id(4)
+                var addr = new byte[16];
+                Marshal.Copy(IntPtr.Add(sockAddrPtr, 8), addr, 0, 16);
+                long scopeId = (uint)Marshal.ReadInt32(sockAddrPtr, 24);
+                return new IPAddress(addr, scopeId);
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #114. Three more fixes from the same analysis.

**WFP event overhead** (commit 1)

`EventMatchAnyKeywords` was BCAST|MCAST, so BFE delivered every inbound broadcast/multicast packet as an RPC callback. The callback discards everything except CLASSIFY_DROP and CLASSIFY_ALLOW - all that unmarshalling for nothing. On a busy network that's hundreds of wasted RPC roundtrips per second.

Known WFP RPC memory bugs in the unmarshalling path (microsoft/Windows-classic-samples #202, #322). Primary suspect for the 2.7 GB leak in #114.

Also resets `CollectNetEvents` on shutdown - the setting persists across reboots.

**Bitmap leak + BeginInvoke race** (commit 2)

`Utils.GetIconContained()` returns a Bitmap. After `ImageList.Images.Add()` nobody disposed it. ImageList copies internally, so the original HBITMAP just leaked.

Also, `listView.BeginInvoke()` had no `IsDisposed` check, so when the form closes mid-scan, posted delegates could run on a disposed control and leak the captured Bitmap.

Previous fix attempt (40d491d, reverted in bb7d035) crashed because `ImageList.Handle` wasn't created yet at the dispose site. This fix disposes inside the BeginInvoke delegate on the UI thread where Handle is guaranteed to exist.

**ProcessStartWatcher lifecycle** (commit 3)

`EventArrived += ...` but no `-=` anywhere. Turns out `ManagementEventWatcher.Dispose()` (from `Component`) doesn't call `Stop()` or touch event subscriptions - only the finalizer does. Since `Dispose()` suppresses finalization via `GC.SuppressFinalize`, the WMI subscription just stayed active.

Fix: unsubscribe -> stop -> dispose.