### PR TITLE
Harden WFP net-event subscription: contain callback exceptions and self-heal dead subscriptions

### DIFF
--- a/TinyWall/TinyWallService.cs
+++ b/TinyWall/TinyWallService.cs
@@ -61,6 +61,16 @@ namespace pylorak.TinyWall
         private readonly ManagementEventWatcher ProcessStartWatcher = new(new WqlEventQuery("SELECT * FROM Win32_ProcessStartTrace"));
         private readonly EventMerger RuleReloadEventMerger = new(1000);
 
+        // WFP net-event subscription resilience. The subscription is a single
+        // point of failure for the blocked-connections log: when it dies
+        // silently (exception in callback, BFE dropping delivery), the log
+        // stops filling and stays empty until the service restarts.
+        private const int NET_EVENT_RECREATE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes without events
+        private NetEventSubscription? NetEventSub;
+        private int LastNetEventTick = Environment.TickCount;
+        private bool NetEventBroken = false;
+        private int LastNetEventErrorLogTick = -60 * 1000;
+
         private HashSet<IpAddrMask> LocalSubnetAddreses = new();
         private HashSet<IpAddrMask> GatewayAddresses = new();
         private HashSet<IpAddrMask> DnsAddresses = new();
@@ -1499,6 +1509,13 @@ namespace pylorak.TinyWall
                         if (!WfpEngine.CollectNetEvents)
                             WfpEngine.CollectNetEvents = true;
 
+                        // Recover a dead net-event subscription. It can die
+                        // silently when an exception escapes the callback or
+                        // when BFE stops delivering events for this session.
+                        if (NetEventBroken || (Environment.TickCount - LastNetEventTick) > NET_EVENT_RECREATE_TIMEOUT_MS)
+                        {
+                            RecreateNetEventSubscription();
+                        }
                         // Check for inactivity and lock if necessary
                         if (DateTime.Now - LastControllerCommandTime > TimeSpan.FromMinutes(10))
                         {
@@ -1675,7 +1692,7 @@ namespace pylorak.TinyWall
             WfpEngine.CollectNetEvents = true;
             using var NetEventCollection = new CallbackOnDispose(() => { try { WfpEngine.CollectNetEvents = false; } catch { } });
             WfpEngine.EventMatchAnyKeywords = InboundEventMatchKeyword.FWPM_NET_EVENT_KEYWORD_INBOUND_BCAST | InboundEventMatchKeyword.FWPM_NET_EVENT_KEYWORD_INBOUND_MCAST;
-            using var WfpEvent = WfpEngine.SubscribeNetEvent(WfpNetEventCallback);
+            RecreateNetEventSubscription();
 
             ProcessStartWatcher.EventArrived += ProcessStartWatcher_EventArrived;
             NetworkInterfaceWatcher.InterfaceChanged += (sender, args) =>
@@ -1715,6 +1732,9 @@ namespace pylorak.TinyWall
                     req.Response = TwMessageError.Instance;
                 }
             }
+
+            NetEventSub?.Dispose();
+            NetEventSub = null;
         }
 
         private void ProcessStartWatcher_EventArrived(object sender, EventArrivedEventArgs e)
@@ -1798,46 +1818,106 @@ namespace pylorak.TinyWall
 
         private void WfpNetEventCallback(NetEventData data)
         {
-            EventLogEvent eventType;
-            if (data.EventType == FWPM_NET_EVENT_TYPE.FWPM_NET_EVENT_TYPE_CLASSIFY_DROP)
-                eventType = EventLogEvent.BLOCKED;
-            else if (data.EventType == FWPM_NET_EVENT_TYPE.FWPM_NET_EVENT_TYPE_CLASSIFY_ALLOW)
-                eventType = EventLogEvent.ALLOWED;
-            else
-                return;
-
-            var entry = new FirewallLogEntry
+            try
             {
-                Timestamp = data.timeStamp,
-                Event = eventType,
-                PackageId = data.packageId,
-                RemoteIp = data.remoteAddr?.ToString(),
-                LocalIp = data.localAddr?.ToString()
-            };
+                EventLogEvent eventType;
+                if (data.EventType == FWPM_NET_EVENT_TYPE.FWPM_NET_EVENT_TYPE_CLASSIFY_DROP)
+                    eventType = EventLogEvent.BLOCKED;
+                else if (data.EventType == FWPM_NET_EVENT_TYPE.FWPM_NET_EVENT_TYPE_CLASSIFY_ALLOW)
+                    eventType = EventLogEvent.ALLOWED;
+                else
+                    return;
 
-            if (!Utils.IsNullOrEmpty(data.appId))
-                entry.AppPath = PathMapper.Instance.ConvertPathIgnoreErrors(data.appId, PathFormat.Win32);
-            else
-                entry.AppPath = "System";
-            if (data.remotePort.HasValue)
-                entry.RemotePort = data.remotePort.Value;
-            if (data.direction.HasValue)
-                entry.Direction = data.direction == FwpmDirection.FWP_DIRECTION_OUT ? RuleDirection.Out : RuleDirection.In;
-            if (data.ipProtocol.HasValue)
-                entry.Protocol = (Protocol)data.ipProtocol;
-            if (data.localPort.HasValue)
-                entry.LocalPort = data.localPort.Value;
+                var entry = new FirewallLogEntry
+                {
+                    Timestamp = data.timeStamp,
+                    Event = eventType,
+                    PackageId = data.packageId,
+                    RemoteIp = data.remoteAddr?.ToString(),
+                    LocalIp = data.localAddr?.ToString()
+                };
 
-            // Replace invalid IP strings with the "unspecified address" IPv6 specifier
-            if (string.IsNullOrEmpty(entry.RemoteIp))
-                entry.RemoteIp = "::";
-            if (string.IsNullOrEmpty(entry.LocalIp))
-                entry.LocalIp = "::";
+                if (!Utils.IsNullOrEmpty(data.appId))
+                    entry.AppPath = PathMapper.Instance.ConvertPathIgnoreErrors(data.appId, PathFormat.Win32);
+                else
+                    entry.AppPath = "System";
+                if (data.remotePort.HasValue)
+                    entry.RemotePort = data.remotePort.Value;
+                if (data.direction.HasValue)
+                    entry.Direction = data.direction == FwpmDirection.FWP_DIRECTION_OUT ? RuleDirection.Out : RuleDirection.In;
+                if (data.ipProtocol.HasValue)
+                    entry.Protocol = (Protocol)data.ipProtocol;
+                if (data.localPort.HasValue)
+                    entry.LocalPort = data.localPort.Value;
 
-            lock (FirewallLogEntries)
-            {
-                FirewallLogEntries.Enqueue(entry);
+                // Replace invalid IP strings with the "unspecified address" IPv6 specifier
+                if (string.IsNullOrEmpty(entry.RemoteIp))
+                    entry.RemoteIp = "::";
+                if (string.IsNullOrEmpty(entry.LocalIp))
+                    entry.LocalIp = "::";
+
+                lock (FirewallLogEntries)
+                {
+                    FirewallLogEntries.Enqueue(entry);
+                }
+
+                LastNetEventTick = Environment.TickCount;
             }
+            catch (Exception e)
+            {
+                // This callback is invoked from native code on a WFP worker
+                // thread. A failure here (e.g. OutOfMemoryException under
+                // memory pressure) must not take the subscription down with it.
+                // Force a resubscribe on the next minute tick.
+                NetEventBroken = true;
+                LogNetEventError(e);
+            }
+        }
+
+        private void NetEventSubscription_CallbackError(Exception e)
+        {
+            // An exception was contained inside the native callback handler in
+            // the WFP wrapper, before it ever reached WfpNetEventCallback().
+            NetEventBroken = true;
+            LogNetEventError(e);
+        }
+
+        private void LogNetEventError(Exception e)
+        {
+            // The callback can fire at a very high rate when things go wrong,
+            // so log at most once per minute.
+            int now = Environment.TickCount;
+            if (now - LastNetEventErrorLogTick > 60 * 1000)
+            {
+                LastNetEventErrorLogTick = now;
+                Utils.LogException(e, Utils.LOG_ID_SERVICE);
+            }
+        }
+
+        // Must be called on the firewall thread only.
+        private void RecreateNetEventSubscription()
+        {
+            if (NetEventSub != null)
+            {
+                try
+                {
+                    NetEventSub.CallbackError -= NetEventSubscription_CallbackError;
+                    NetEventSub.Dispose();
+                }
+                catch (Exception e)
+                {
+                    LogNetEventError(e);
+                }
+                finally
+                {
+                    NetEventSub = null;
+                }
+            }
+
+            NetEventSub = WfpEngine.SubscribeNetEvent(WfpNetEventCallback);
+            NetEventSub.CallbackError += NetEventSubscription_CallbackError;
+            NetEventBroken = false;
+            LastNetEventTick = Environment.TickCount;
         }
 
         private void AutoLearnLogEntry(FirewallLogEntry entry)

--- a/pylorak.Windows.WFP/NetEventSubscription.cs
+++ b/pylorak.Windows.WFP/NetEventSubscription.cs
@@ -72,6 +72,22 @@ namespace pylorak.Windows.WFP
             return sb.ToString();
         }
 
+        private static string? ReadAppId(Interop.FWP_BYTE_BLOB blob)
+        {
+            if (blob.size == 0 || blob.data == IntPtr.Zero)
+                return null;
+
+            // The blob size is in bytes and the payload is a null-terminated
+            // Unicode string. Bound the read by the declared size so a missing
+            // terminator cannot make us scan past the end of the buffer.
+            string str = Marshal.PtrToStringUni(blob.data, (int)(blob.size / 2));
+            int terminator = str.IndexOf('\0');
+            if (terminator >= 0)
+                str = str.Substring(0, terminator);
+
+            return str;
+        }
+
         private static void ToHex(byte b, StringBuilder sb)
         {
             var n = (byte)(b >> 4);
@@ -122,7 +138,7 @@ namespace pylorak.Windows.WFP
 
             if ((flags & Interop.NetEventHeaderValidField.FWPM_NET_EVENT_FLAG_APP_ID_SET) != 0)
             {
-                appId = Marshal.PtrToStringAuto(nativeEvent.header.appId.data);
+                appId = ReadAppId(nativeEvent.header.appId);
             }
             if ((flags & Interop.NetEventHeaderValidField.FWPM_NET_EVENT_FLAG_IP_PROTOCOL_SET) != 0)
             {
@@ -167,7 +183,7 @@ namespace pylorak.Windows.WFP
 
             if ((flags & Interop.NetEventHeaderValidField.FWPM_NET_EVENT_FLAG_APP_ID_SET) != 0)
             {
-                appId = Marshal.PtrToStringAuto(nativeEvent.header.appId.data);
+                appId = ReadAppId(nativeEvent.header.appId);
             }
             if ((flags & Interop.NetEventHeaderValidField.FWPM_NET_EVENT_FLAG_IP_PROTOCOL_SET) != 0)
             {
@@ -223,8 +239,30 @@ namespace pylorak.Windows.WFP
     public abstract class NetEventSubscription : IDisposable
     {
         protected readonly NetEventCallback _callback;
-        protected readonly StringBuilder SBuilder = new(40);
-        
+
+        // Raised when an exception was contained inside a native callback handler.
+        // Runs on the WFP callback thread, so handlers must not block or throw.
+        public event Action<Exception>? CallbackError;
+
+        // WFP does not document that callbacks are serialized, so the scratch
+        // builder must be per-thread.
+        [ThreadStatic]
+        private static StringBuilder? SBuilder;
+
+        protected static StringBuilder GetScratchBuilder()
+        {
+            if (SBuilder is null)
+                SBuilder = new StringBuilder(40);
+            return SBuilder;
+        }
+
+        // C# restricts invoking an event to the declaring type, so derived
+        // subscription classes report through this hook instead.
+        protected void OnCallbackError(Exception e)
+        {
+            try { CallbackError?.Invoke(e); } catch { }
+        }
+
         public bool IsDisposed { get; private set; }
 
         protected NetEventSubscription(NetEventCallback callback)
@@ -287,12 +325,22 @@ namespace pylorak.Windows.WFP
             else
                 throw new WfpException(err, "FwpmNetEventSubscribe0");
         }
-
         private void NativeCallbackHandler0(IntPtr context, IntPtr netEvent1)
         {
-            Interop.FWPM_NET_EVENT1 ev = PInvokeHelper.PtrToStructure<Interop.FWPM_NET_EVENT1>(netEvent1);
-            _callback(new NetEventData(ev, SBuilder));
+            try
+            {
+                Interop.FWPM_NET_EVENT1 ev = PInvokeHelper.PtrToStructure<Interop.FWPM_NET_EVENT1>(netEvent1);
+                _callback(new NetEventData(ev, GetScratchBuilder()));
+            }
+            catch (Exception e)
+            {
+                // Never let an exception cross the reverse P/Invoke boundary
+                // into FWPUClnt.dll: on .NET Framework this terminates the
+                // process, and event delivery is lost either way.
+                OnCallbackError(e);
+            }
         }
+
 
         protected override void Dispose(bool disposing)
         {
@@ -345,11 +393,18 @@ namespace pylorak.Windows.WFP
             else
                 throw new WfpException(err, "FwpmNetEventSubscribe1");
         }
-
         private void NativeCallbackHandler1(IntPtr context, IntPtr netEvent1)
         {
-            var ev = PInvokeHelper.PtrToStructure<Interop.FWPM_NET_EVENT2>(netEvent1);
-            _callback(new NetEventData(ev, SBuilder));
+            try
+            {
+                var ev = PInvokeHelper.PtrToStructure<Interop.FWPM_NET_EVENT2>(netEvent1);
+                _callback(new NetEventData(ev, GetScratchBuilder()));
+            }
+            catch (Exception e)
+            {
+                // See NativeCallbackHandler0 for the rationale.
+                OnCallbackError(e);
+            }
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
# Harden WFP net-event subscription: contain callback exceptions and self-heal dead subscriptions

## Problem

The Connections window's "Show blocked apps" list is fed exclusively by the WFP
net-event subscription running inside the TinyWall *service*:

`FwpmNetEventSubscribe1` → `NativeCallbackHandler1` → `WfpNetEventCallback` →
`CircularBuffer<FirewallLogEntry>` → `READ_FW_LOG` pipe message.

A single failure in this pipeline (e.g. `OutOfMemoryException` under memory
pressure, or BFE dropping delivery) kills the subscription **silently**:

- nothing is logged (`service.log` untouched),
- nothing crashes (no `.NET Runtime`/`WER` events; SCM keeps the service running),
- the blocked list stays empty forever, because `ConnectionsForm` filters
  entries older than 5 minutes and the buffer never refills.

Restarting only the controller cannot help: the subscription and its ring
buffer live in the service process. `services.msc` cannot restart the service
either, because release builds accept only `SERVICE_ACCEPT_SHUTDOWN |
SERVICE_ACCEPT_POWEREVENT`.

### Reproduction (live system, TinyWall 3.4.1, Win10 26100)

1. BFE ran out of memory: `service.log` shows `WfpException: FwpmFilterEnum0
   returned error code 14` (= Win32 `ERROR_OUTOFMEMORY`).
2. Afterwards the blocked list in Connections is empty while "Show active
   connections" still works (those come from live NetStat tables, not the log).
3. The service process (restarted 2026-08-10 17:10 by SCM) still produced an
   empty list — the failure recurs and the subscription never recovers.
4. Force-restarting the service (kill → SCM restart-on-failure in 1 s)
   immediately restored the list. Diagnosis confirmed live.

## Changes

### pylorak.Windows.WFP/NetEventSubscription.cs

- **Contain exceptions in both native callback handlers.** Nothing may cross
  the reverse P/Invoke boundary into `FWPUClnt.dll`; on .NET Framework this
  terminates the process and loses event delivery.
- **Report contained exceptions** through a new `CallbackError` event so the
  host can detect a broken subscription.
- **Bound the `appId` read by `FWP_BYTE_BLOB.size`** instead of scanning for a
  NUL terminator; trim at the terminator afterwards. A missing terminator can
  no longer make us read past the buffer.
- **Make the IP-formatting scratch `StringBuilder` per-thread**
  (`[ThreadStatic]`), keeping the zero-allocation intent without assuming WFP
  serializes callbacks.

### TinyWall/TinyWallService.cs

- **Wrap `WfpNetEventCallback`** in try/catch; log rate-limited (≤1/min),
  never rethrow.
- **Self-healing watchdog:** track the last event timestamp; on the minute
  timer, if an error was contained or no events arrived for 5 minutes,
  dispose and recreate the subscription. Re-creation happens only on the
  firewall thread.
- The subscription is now a service-lifetime member, disposed on shutdown
  (`Run()` exit), created initially in `Run()` as before.

## Verification

- `pylorak.Windows.WFP` project builds clean (0 errors, 0 warnings from these
  files).
- Full compile check of the TinyWall source set (129 source files + NuGet
  dependencies) against .NET Framework 4.8 reference assemblies: 0 errors.
  (COM-interop entry files stubbed locally because the build machine lacks
  the NETFXSDK tools; the changed code paths do not touch those stubs.)
- Live-system confirmation: after service restart the blocked list
  repopulated immediately (see reproduction above).

## Notes

- The watchdog re-subscribes after 5 quiet minutes. On a machine with no
  blocked traffic this is an inexpensive no-op RPC; when the subscription has
  died silently this restores the log within at most ~6 minutes.
- If `SubscribeNetEvent` itself throws during recreation, the exception is
  logged and retried on the next minute tick; at service startup the behavior
  is unchanged (service fails to start, as before).
# Harden WFP net-event subscription: contain callback exceptions and self-heal dead subscriptions

## Problem

The Connections window's "Show blocked apps" list is fed exclusively by the WFP
net-event subscription running inside the TinyWall *service*:

`FwpmNetEventSubscribe1` → `NativeCallbackHandler1` → `WfpNetEventCallback` →
`CircularBuffer<FirewallLogEntry>` → `READ_FW_LOG` pipe message.

A single failure in this pipeline (e.g. `OutOfMemoryException` under memory
pressure, or BFE dropping delivery) kills the subscription **silently**:

- nothing is logged (`service.log` untouched),
- nothing crashes (no `.NET Runtime`/`WER` events; SCM keeps the service running),
- the blocked list stays empty forever, because `ConnectionsForm` filters
  entries older than 5 minutes and the buffer never refills.

Restarting only the controller cannot help: the subscription and its ring
buffer live in the service process. `services.msc` cannot restart the service
either, because release builds accept only `SERVICE_ACCEPT_SHUTDOWN |
SERVICE_ACCEPT_POWEREVENT`.

### Reproduction (live system, TinyWall 3.4.1, Win10 26100)

1. BFE ran out of memory: `service.log` shows `WfpException: FwpmFilterEnum0
   returned error code 14` (= Win32 `ERROR_OUTOFMEMORY`).
2. Afterwards the blocked list in Connections is empty while "Show active
   connections" still works (those come from live NetStat tables, not the log).
3. The service process (restarted 2026-08-10 17:10 by SCM) still produced an
   empty list — the failure recurs and the subscription never recovers.
4. Force-restarting the service (kill → SCM restart-on-failure in 1 s)
   immediately restored the list. Diagnosis confirmed live.

## Changes

### pylorak.Windows.WFP/NetEventSubscription.cs

- **Contain exceptions in both native callback handlers.** Nothing may cross
  the reverse P/Invoke boundary into `FWPUClnt.dll`; on .NET Framework this
  terminates the process and loses event delivery.
- **Report contained exceptions** through a new `CallbackError` event so the
  host can detect a broken subscription.
- **Bound the `appId` read by `FWP_BYTE_BLOB.size`** instead of scanning for a
  NUL terminator; trim at the terminator afterwards. A missing terminator can
  no longer make us read past the buffer.
- **Make the IP-formatting scratch `StringBuilder` per-thread**
  (`[ThreadStatic]`), keeping the zero-allocation intent without assuming WFP
  serializes callbacks.

### TinyWall/TinyWallService.cs

- **Wrap `WfpNetEventCallback`** in try/catch; log rate-limited (≤1/min),
  never rethrow.
- **Self-healing watchdog:** track the last event timestamp; on the minute
  timer, if an error was contained or no events arrived for 5 minutes,
  dispose and recreate the subscription. Re-creation happens only on the
  firewall thread.
- The subscription is now a service-lifetime member, disposed on shutdown
  (`Run()` exit), created initially in `Run()` as before.

## Verification

- `pylorak.Windows.WFP` project builds clean (0 errors, 0 warnings from these
  files).
- Full compile check of the TinyWall source set (129 source files + NuGet
  dependencies) against .NET Framework 4.8 reference assemblies: 0 errors.
  (COM-interop entry files stubbed locally because the build machine lacks
  the NETFXSDK tools; the changed code paths do not touch those stubs.)
- Live-system confirmation: after service restart the blocked list
  repopulated immediately (see reproduction above).

## Notes

- The watchdog re-subscribes after 5 quiet minutes. On a machine with no
  blocked traffic this is an inexpensive no-op RPC; when the subscription has
  died silently this restores the log within at most ~6 minutes.
- If `SubscribeNetEvent` itself throws during recreation, the exception is
  logged and retried on the next minute tick; at service startup the behavior
  is unchanged (service fails to start, as before).
