### PR TITLE
Fix MSI packaging in the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,4 +110,5 @@ jobs:
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: ${{ steps.version.outputs.msi_name }}
-        path: MsiSetup/bin/Release/TinyWallInstaller.msi
+        path: MsiSetup/bin/Release/TinyWall_x86.msi
+        if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,8 @@ jobs:
       run: |
         $src = 'TinyWall/bin/Release'
         $dst = 'MsiSetup/Sources/ProgramFiles/TinyWall'
+        # MsiSetup/Sources is gitignored, so it does not exist in a fresh clone.
+        New-Item -ItemType Directory -Path $dst -Force | Out-Null
         Copy-Item "$src/TinyWall.exe" "$dst/" -Force
         Copy-Item "$src/TinyWall.exe.config" "$dst/" -Force
         Get-ChildItem "$src/*.dll" | Copy-Item -Destination "$dst/" -Force

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,20 @@ jobs:
             Copy-Item $satellite "$dst/$lang/" -Force
           }
         }
+        # Product.wxs also links in the docs, licence, icon and the CommonAppData
+        # payload, so staging the binaries alone is not enough to build the MSI.
+        # Mirrors steps 3 and 4 of build.ps1.
+        $appdata = 'MsiSetup/Sources/CommonAppData/TinyWall'
+        New-Item -ItemType Directory -Path $appdata -Force | Out-Null
+        Copy-Item 'MsiSetup/License.rtf' "$dst/" -Force
+        Copy-Item 'TinyWall/Resources/img/TinyWall.ico' "$dst/" -Force
+        Copy-Item 'TinyWall/doc' "$dst/doc" -Recurse -Force
+        Copy-Item 'TinyWall/Resources/hosts' "$appdata/hosts.custom" -Force
+        # TinyWall.exe is a GUI-subsystem binary, so wait for it explicitly.
+        $proc = Start-Process -FilePath "$src/TinyWall.exe" -NoNewWindow -Wait -PassThru -ArgumentList @(
+          'database-creator', '/source-folder', 'TinyWall/Database', '/output-folder', $appdata
+        )
+        if ($proc.ExitCode -ne 0) { throw "database-creator failed with exit code $($proc.ExitCode)" }
 
     - name: Build MSI
       if: matrix.configuration == 'Release'


### PR DESCRIPTION
Three bugs prevent `.github/workflows/build.yml` from producing an installer. They are latent
rather than visible, because the MSI steps only run on a manual `workflow_dispatch` — each one
hides the next, so they surface in sequence.

**1. The staging directory is never created.** `MsiSetup/Sources` is gitignored, so it does not
exist in a fresh clone and the staging step fails on its first copy with "Could not find a part
of the path".

**2. Only the binaries are staged.** `Product.wxs` also links in the documentation, licence,
application icon and the `CommonAppData` files, so `Build MSI` fails with eight `LGHT0103`
errors:

```
Product.wxs(343): error LGHT0103: The system cannot find the file
  'Sources\ProgramFiles\TinyWall\TinyWall.ico'.
Product.wxs(293): error LGHT0103: The system cannot find the file
  'Sources\CommonAppData\TinyWall\profiles.json'.
...
```

This commit stages the same set `build.ps1` does in its steps 3 and 4: `doc`, `License.rtf` and
`TinyWall.ico` into ProgramFiles, the bundled hosts file as `hosts.custom`, and `profiles.json`
generated from `TinyWall\Database` by the `database-creator` tool. `TinyWall.exe` is a
GUI-subsystem binary, so it is started and waited for explicitly rather than run from the shell,
which would not block.

**3. The upload points at a filename WiX does not produce.** The step uploads
`TinyWallInstaller.msi`, but the project emits `TinyWall_x86.msi`:

```
##[warning]No files were found with the provided path:
  MsiSetup/bin/Release/TinyWallInstaller.msi. No artifacts will be uploaded.
```

`actions/upload-artifact` downgrades a non-match to a warning, so the job passes while producing
no installer at all. Fixed by pointing at the real output and setting `if-no-files-found: error`,
so a future rename fails the build instead of silently uploading nothing.

## Validation

Verified by dispatching this branch, which is otherwise identical to `master`: all four matrix
jobs green, both MSIs built and uploaded at the current 3.5.1 version.

https://github.com/ChrisRosser/TinyWall/actions/runs/33751696461

## Scope

Workflow only — one file, no source or version changes, and the triggers are left commented out
exactly as they are. Independent of #133; either can merge without the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
