### PR TITLE
Run the build workflow on push and pull request

### DIFF
--- a/.github/scripts/test-relocation.ps1
+++ b/.github/scripts/test-relocation.ps1
@@ -136,6 +136,43 @@ try {
     Assert-Relocation 'the deepest versioned folder is tried first' `
         'AppFifteen\rel-2.0\app-1.0\app.exe' 'AppFifteen\rel-2.0\app-1.1\app.exe'
 
+    # --- MSIX / Microsoft Store layout: Name_Version_Arch__PublisherId ---
+    # A synthesized tree only; the real WindowsApps folder is never touched.
+    New-Exe 'WindowsApps\Claude_1.44122.0.0_x64__pzs8sxrjxfjjc\app\claude.exe' | Out-Null
+    Assert-Relocation 'msix package update is followed' `
+        'WindowsApps\Claude_1.44121.2.0_x64__pzs8sxrjxfjjc\app\claude.exe' `
+        'WindowsApps\Claude_1.44122.0.0_x64__pzs8sxrjxfjjc\app\claude.exe'
+
+    New-Exe 'MsixTwo\Contoso_2.1.0.0_x64__abcdefgh12345\app.exe'  | Out-Null
+    New-Exe 'MsixTwo\Contoso_2.10.0.0_x64__abcdefgh12345\app.exe' | Out-Null
+    New-Exe 'MsixTwo\Contoso_2.2.0.0_x64__abcdefgh12345\app.exe'  | Out-Null
+    Assert-Relocation 'msix highest version wins, compared numerically' `
+        'MsixTwo\Contoso_2.0.0.0_x64__abcdefgh12345\app.exe' `
+        'MsixTwo\Contoso_2.10.0.0_x64__abcdefgh12345\app.exe'
+
+    New-Exe 'MsixThree\Contoso_2.0.0.0_x64__zzzzzzzzzzzzz\app.exe' | Out-Null
+    Assert-Relocation 'a different publisher id is not followed' `
+        'MsixThree\Contoso_1.0.0.0_x64__abcdefgh12345\app.exe' ''
+
+    New-Exe 'MsixFour\Contoso_2.0.0.0_arm64__abcdefgh12345\app.exe' | Out-Null
+    Assert-Relocation 'a different architecture is not followed' `
+        'MsixFour\Contoso_1.0.0.0_x64__abcdefgh12345\app.exe' ''
+
+    New-Exe 'MsixFive\Fabrikam_2.0.0.0_x64__abcdefgh12345\app.exe' | Out-Null
+    Assert-Relocation 'a different package name is not followed' `
+        'MsixFive\Contoso_1.0.0.0_x64__abcdefgh12345\app.exe' ''
+
+    # The two rules must stay disjoint in both directions: an MSIX-shaped folder is never
+    # relocated onto a Squirrel-style sibling, and vice versa, even though both carry a
+    # version and sit side by side under the same parent.
+    New-Exe 'MsixSix\Contoso-2.0.0\app.exe' | Out-Null
+    Assert-Relocation 'an msix name is not matched by the generic rule' `
+        'MsixSix\Contoso_1.0.0.0_x64__abcdefgh12345\app.exe' ''
+
+    New-Exe 'MsixSeven\app_2.0.0.0_x64__abcdefgh12345\app.exe' | Out-Null
+    Assert-Relocation 'a squirrel-style name is not matched by the msix rule' `
+        'MsixSeven\app-1.2.3\app.exe' ''
+
     Write-Host ''
     Write-Host "$($script:Total - $script:Failures)/$($script:Total) passed"
 }

--- a/.github/scripts/test-relocation.ps1
+++ b/.github/scripts/test-relocation.ps1
@@ -1,0 +1,150 @@
+<#
+    Behavioural tests for ExecutableRelocator, run against a real build of TinyWall.exe.
+
+    Builds a throwaway directory tree that mimics the layouts used by Squirrel/Electron
+    installers, then asks the executable's "relocation-test" dev command what the service
+    would do with each stored exception path.
+
+    Usage:
+        test-relocation.ps1 -Exe <path to TinyWall.exe>
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Exe
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $Exe)) {
+    throw "Executable not found: $Exe"
+}
+
+$Root = Join-Path ([System.IO.Path]::GetTempPath()) ("tw-reloc-" + [System.Guid]::NewGuid().ToString('N'))
+$ResultFile = Join-Path $Root 'result.txt'
+
+function New-Exe([string]$RelativePath) {
+    $full = Join-Path $Root $RelativePath
+    New-Item -ItemType Directory -Path (Split-Path -Parent $full) -Force | Out-Null
+    Set-Content -LiteralPath $full -Value 'not a real executable' -NoNewline
+    return $full
+}
+
+function New-Dir([string]$RelativePath) {
+    $full = Join-Path $Root $RelativePath
+    New-Item -ItemType Directory -Path $full -Force | Out-Null
+    return $full
+}
+
+$script:Failures = 0
+$script:Total = 0
+
+function Assert-Relocation([string]$Name, [string]$OldRelative, [string]$ExpectedRelative) {
+    $script:Total++
+
+    $old = Join-Path $Root $OldRelative
+    $expected = if ([string]::IsNullOrEmpty($ExpectedRelative)) { '' } else { Join-Path $Root $ExpectedRelative }
+
+    if (Test-Path -LiteralPath $ResultFile) { Remove-Item -LiteralPath $ResultFile -Force }
+
+    $proc = Start-Process -FilePath $Exe -NoNewWindow -Wait -PassThru -ArgumentList @(
+        'relocation-test',
+        '/executable-path', "`"$old`"",
+        '/output-file', "`"$ResultFile`""
+    )
+
+    $actual = if (Test-Path -LiteralPath $ResultFile) { (Get-Content -LiteralPath $ResultFile -Raw) } else { '' }
+    if ($null -eq $actual) { $actual = '' }
+    $actual = $actual.Trim()
+
+    # Exit code must agree with the written result: 0 = found, non-zero = nothing found.
+    $expectedExit = if ($expected -eq '') { 1 } else { 0 }
+
+    if (($actual -ieq $expected) -and ($proc.ExitCode -eq $expectedExit)) {
+        Write-Host "PASS  $Name"
+    }
+    else {
+        $script:Failures++
+        Write-Host "FAIL  $Name"
+        Write-Host "      stored   : $old"
+        Write-Host "      expected : $(if ($expected -eq '') { '(no match)' } else { $expected }) [exit $expectedExit]"
+        Write-Host "      actual   : $(if ($actual -eq '') { '(no match)' } else { $actual }) [exit $($proc.ExitCode)]"
+    }
+}
+
+try {
+    # --- Squirrel/Electron layout: version folders side by side ---
+    New-Exe 'AnthropicClaude\app-0.10.0\claude.exe' | Out-Null
+    New-Exe 'AnthropicClaude\app-0.11.0\claude.exe' | Out-Null
+    New-Exe 'AnthropicClaude\app-0.9.3\other.exe'   | Out-Null
+    Assert-Relocation 'update picks the highest version, compared numerically' `
+        'AnthropicClaude\app-0.9.3\claude.exe' 'AnthropicClaude\app-0.11.0\claude.exe'
+
+    New-Exe 'Discord\app-1.3.0\modules\voice\helper.exe' | Out-Null
+    Assert-Relocation 'sub-path below the versioned folder is preserved' `
+        'Discord\app-1.2.3\modules\voice\helper.exe' 'Discord\app-1.3.0\modules\voice\helper.exe'
+
+    New-Exe 'AppFour\app-2.0\somethingelse.exe' | Out-Null
+    Assert-Relocation 'a different file name is not followed' `
+        'AppFour\app-1.0\wanted.exe' ''
+
+    New-Exe 'AppFive\application-2.0\x.exe' | Out-Null
+    Assert-Relocation 'a different folder stem is not followed' `
+        'AppFive\app-1.0\x.exe' ''
+
+    Assert-Relocation 'a missing install root is not followed (offline volume)' `
+        'NoSuchRoot\app-1.0\x.exe' ''
+
+    New-Dir 'AppSeven' | Out-Null
+    Assert-Relocation 'an uninstalled application is left alone' `
+        'AppSeven\app-1.0\x.exe' ''
+
+    New-Exe 'AppEight\lib\x.exe' | Out-Null
+    Assert-Relocation 'folder names without a version token are ignored' `
+        'AppEight\bin\x.exe' ''
+
+    New-Dir 'AppNine\app-1.0.0' | Out-Null
+    New-Exe 'AppNine\app-1.1.0\app.exe' | Out-Null
+    Assert-Relocation 'old folder left behind without the executable' `
+        'AppNine\app-1.0.0\app.exe' 'AppNine\app-1.1.0\app.exe'
+
+    New-Exe 'AppTen\app-1.2.3-beta.1\app.exe' | Out-Null
+    Assert-Relocation 'prerelease suffix in the folder name' `
+        'AppTen\app-1.2.2\app.exe' 'AppTen\app-1.2.3-beta.1\app.exe'
+
+    New-Exe 'AppEleven\2.0.0\app.exe' | Out-Null
+    Assert-Relocation 'bare version folder with no stem' `
+        'AppEleven\1.2.3\app.exe' 'AppEleven\2.0.0\app.exe'
+
+    New-Exe 'AppTwelve\app-0.8.0\app.exe' | Out-Null
+    Assert-Relocation 'rollback is followed when it is the only candidate' `
+        'AppTwelve\app-0.9.3\app.exe' 'AppTwelve\app-0.8.0\app.exe'
+
+    $older = New-Exe 'AppThirteen\app-1.2\app.exe'
+    $newer = New-Exe 'AppThirteen\app-1.2.0\app.exe'
+    (Get-Item -LiteralPath $older).LastWriteTimeUtc = [DateTime]::UtcNow.AddDays(-2)
+    (Get-Item -LiteralPath $newer).LastWriteTimeUtc = [DateTime]::UtcNow
+    Assert-Relocation 'equal versions are broken by the newer file' `
+        'AppThirteen\app-1.1\app.exe' 'AppThirteen\app-1.2.0\app.exe'
+
+    $existing = New-Exe 'AppFourteen\app-1.0\app.exe'
+    Assert-Relocation 'a path that still exists is never rewritten' `
+        'AppFourteen\app-1.0\app.exe' ''
+
+    New-Exe 'AppFifteen\rel-2.0\app-1.1\app.exe' | Out-Null
+    New-Exe 'AppFifteen\rel-3.0\app-1.0\app.exe' | Out-Null
+    Assert-Relocation 'the deepest versioned folder is tried first' `
+        'AppFifteen\rel-2.0\app-1.0\app.exe' 'AppFifteen\rel-2.0\app-1.1\app.exe'
+
+    Write-Host ''
+    Write-Host "$($script:Total - $script:Failures)/$($script:Total) passed"
+}
+finally {
+    if (Test-Path -LiteralPath $Root) {
+        Remove-Item -LiteralPath $Root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if ($script:Failures -gt 0) {
+    exit 1
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,4 +110,5 @@ jobs:
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: ${{ steps.version.outputs.msi_name }}
-        path: MsiSetup/bin/Release/TinyWallInstaller.msi
+        path: MsiSetup/bin/Release/TinyWall_x86.msi
+        if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,8 @@ jobs:
       run: |
         $src = 'TinyWall/bin/Release'
         $dst = 'MsiSetup/Sources/ProgramFiles/TinyWall'
+        # MsiSetup/Sources is gitignored, so it does not exist in a fresh clone.
+        New-Item -ItemType Directory -Path $dst -Force | Out-Null
         Copy-Item "$src/TinyWall.exe" "$dst/" -Force
         Copy-Item "$src/TinyWall.exe.config" "$dst/" -Force
         Get-ChildItem "$src/*.dll" | Copy-Item -Destination "$dst/" -Force

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,10 @@
 name: Build
 
 on:
-  # push:
-  #   branches: [master]
-  # pull_request:
-  #   branches: [master]
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
   workflow_dispatch:
 
 permissions:
@@ -41,6 +41,10 @@ jobs:
 
     - name: Build
       run: msbuild TinyWall/TinyWall.csproj /p:Configuration=${{ matrix.configuration }} /p:RestorePackages=false
+
+    - name: Run relocation tests
+      shell: pwsh
+      run: .github/scripts/test-relocation.ps1 -Exe "TinyWall/bin/${{ matrix.configuration }}/TinyWall.exe"
 
     - name: Upload build output
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,20 @@ jobs:
             Copy-Item $satellite "$dst/$lang/" -Force
           }
         }
+        # Product.wxs also links in the docs, licence, icon and the CommonAppData
+        # payload, so staging the binaries alone is not enough to build the MSI.
+        # Mirrors steps 3 and 4 of build.ps1.
+        $appdata = 'MsiSetup/Sources/CommonAppData/TinyWall'
+        New-Item -ItemType Directory -Path $appdata -Force | Out-Null
+        Copy-Item 'MsiSetup/License.rtf' "$dst/" -Force
+        Copy-Item 'TinyWall/Resources/img/TinyWall.ico' "$dst/" -Force
+        Copy-Item 'TinyWall/doc' "$dst/doc" -Recurse -Force
+        Copy-Item 'TinyWall/Resources/hosts' "$appdata/hosts.custom" -Force
+        # TinyWall.exe is a GUI-subsystem binary, so wait for it explicitly.
+        $proc = Start-Process -FilePath "$src/TinyWall.exe" -NoNewWindow -Wait -PassThru -ArgumentList @(
+          'database-creator', '/source-folder', 'TinyWall/Database', '/output-folder', $appdata
+        )
+        if ($proc.ExitCode -ne 0) { throw "database-creator failed with exit code $($proc.ExitCode)" }
 
     - name: Build MSI
       if: matrix.configuration == 'Release'

--- a/TinyWall/CmdLineArgs.cs
+++ b/TinyWall/CmdLineArgs.cs
@@ -251,6 +251,30 @@ namespace pylorak.TinyWall
         }
     }
 
+    public class RelocationTestCliArgs : CliArgsBase
+    {
+        public CliArg<string> ExecutablePath { get; init; } = new() { Name = "/executable-path", IsRequired = true };
+        public CliArg<string> OutputFile { get; init; } = new() { Name = "/output-file" };
+
+        protected override void OnParse(string[] args, bool[] keep)
+        {
+            for (int i = 0; i < args.Length; ++i)
+            {
+                string arg = args[i].ToLowerInvariant();
+
+                if (ExecutablePath.Name == arg)
+                    ExecutablePath.Value = (++i < args.Length) ? args[i] : throw new MissingCommandlineValueException(arg);
+                else if (OutputFile.Name == arg)
+                    OutputFile.Value = (++i < args.Length) ? args[i] : throw new MissingCommandlineValueException(arg);
+                else
+                    keep[i] = true;
+            }
+
+            ExecutablePath.ThrowIfRequiredAndUnassigned();
+            OutputFile.ThrowIfRequiredAndUnassigned();
+        }
+    }
+
     public enum StartupCommand
     {
         // Default to check for uninitilaized values
@@ -267,6 +291,7 @@ namespace pylorak.TinyWall
         UpdateCreator,
         ResXOptimizer,
         BatchSigner,
+        RelocationTest,
 
         // Only the following are meant for end-users:
         Update
@@ -282,6 +307,7 @@ namespace pylorak.TinyWall
         public UpdateCreatorCliArgs UpdateCreator { get; } = new();
         public ResXOptimizerCliArgs ResXOptimizer { get; } = new();
         public BatchSignerCliArgs BatchSigner { get; } = new();
+        public RelocationTestCliArgs RelocationTest { get; } = new();
 
         public void ParseArgs(string[] args)
         {
@@ -305,6 +331,7 @@ namespace pylorak.TinyWall
                     "update-creator" => StartupCommand.UpdateCreator,
                     "resx-optimizer" => StartupCommand.ResXOptimizer,
                     "batch-signer" => StartupCommand.BatchSigner,
+                    "relocation-test" => StartupCommand.RelocationTest,
                     _ when args[0].StartsWith("/") => StartupCommand.Invalid,
                     _ => throw new InvalidCommandlineOptionException(args[0])
                 };
@@ -346,6 +373,9 @@ namespace pylorak.TinyWall
                     break;
                 case StartupCommand.BatchSigner:
                     BatchSigner.Parse(ref optsOnly);
+                    break;
+                case StartupCommand.RelocationTest:
+                    RelocationTest.Parse(ref optsOnly);
                     break;
             }
 

--- a/TinyWall/DevelToolCli.cs
+++ b/TinyWall/DevelToolCli.cs
@@ -34,6 +34,32 @@ namespace pylorak.TinyWall
             return Encoding.UTF8.GetString(utf8bytes);
         }
 
+        // --- Relocation Test ---
+
+        // Dry-run for ExecutableRelocator: reports what the service would do with a stored
+        // exception path, without touching the firewall configuration. Handy for checking the
+        // behaviour against a real installation, e.g.
+        //   TinyWall.exe relocation-test /executable-path "%LOCALAPPDATA%\AnthropicClaude\app-0.9.3\claude.exe"
+        //
+        // TinyWall is a WinExe, so its console output cannot be captured reliably by a calling
+        // script. Pass /output-file to have the result written somewhere a script can read it.
+        public static bool TestRelocation(string exePath, string? outputFile)
+        {
+            exePath = ExecutableSubject.ResolvePath(exePath);
+            bool found = ExecutableRelocator.TryFindRelocatedPath(exePath, out string newPath);
+
+            Console.WriteLine($"Stored path  : {exePath}");
+            Console.WriteLine($"Still exists : {File.Exists(exePath)}");
+            Console.WriteLine(found
+                ? $"Would follow : {newPath}"
+                : "Would follow : (nothing found, exception would be left unchanged)");
+
+            if (!Utils.IsNullOrEmpty(outputFile))
+                File.WriteAllText(outputFile, found ? newPath : string.Empty);
+
+            return found;
+        }
+
         // --- Database Creator ---
 
         public static void CreateDatabase(string sourceFolder, string outputFolder)

--- a/TinyWall/ExecutableRelocator.cs
+++ b/TinyWall/ExecutableRelocator.cs
@@ -17,7 +17,13 @@ namespace pylorak.TinyWall
     /// the user notices and re-whitelists it by hand. Such applications update frequently, which
     /// makes this a recurring annoyance rather than a one-off.
     ///
-    /// This helper detects that specific situation and nothing else. The replacement must live in a
+    /// MSIX / Microsoft Store packages behave the same way, but put the version in the middle of
+    /// the folder name instead of at its end:
+    ///     C:\Program Files\WindowsApps\Claude_1.44121.2.0_x64__pzs8sxrjxfjjc\app\claude.exe
+    /// There the package name, architecture and publisher id must all be preserved and only the
+    /// version may change, which is a stricter test than the generic one below.
+    ///
+    /// This helper detects those specific situations and nothing else. The replacement must live in a
     /// *sibling* directory of the original one whose name differs from it only in a version token,
     /// and the path below that directory - including the file name - must be identical. The trust
     /// boundary is therefore unchanged: anyone able to plant a file that this code would relocate to
@@ -32,6 +38,16 @@ namespace pylorak.TinyWall
         //   "2.14.0"       -> stem "",         version "2.14.0"
         private static readonly Regex VersionedFolderRegex = new(
             @"^(?<stem>.*?)[-_. ]?v?(?<version>\d+(?:\.\d+)*)(?<suffix>[-+][0-9A-Za-z.]+)?$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+        // Matches MSIX / Microsoft Store package folders, which carry the version in the middle
+        // of the name rather than at its end and so are never matched by the rule above:
+        //   "Claude_1.44121.2.0_x64__pzs8sxrjxfjjc"
+        //       -> name "Claude", version "1.44121.2.0", arch "x64", publisher "pzs8sxrjxfjjc"
+        // The layout is Name_Version_Arch__PublisherId. Name and architecture cannot contain an
+        // underscore, which is what keeps the fields unambiguous.
+        private static readonly Regex MsixPackageFolderRegex = new(
+            @"^(?<name>[^_]+)_(?<version>\d+(?:\.\d+){0,3})_(?<arch>[^_]+)__(?<pub>[A-Za-z0-9]+)$",
             RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
         // How many directory levels above the executable may be the versioned one.
@@ -78,13 +94,18 @@ namespace pylorak.TinyWall
 
                     if (!Utils.IsNullOrEmpty(name) && (parent is not null))
                     {
-                        var match = VersionedFolderRegex.Match(name);
+                        // A packaged folder is handled by the MSIX rule and never by the generic
+                        // one: the two are tried in order and the first match decides which
+                        // identity has to be preserved among the siblings.
+                        var msixMatch = MsixPackageFolderRegex.Match(name);
+                        bool isMsix = msixMatch.Success;
+                        var match = isMsix ? msixMatch : VersionedFolderRegex.Match(name);
 
                         // The parent must still exist. If it does not, we are not looking at an
                         // updated application but at a detached drive or a deleted install root.
                         if (match.Success && Directory.Exists(parent))
                         {
-                            if (TryRelocateWithin(parent!, name, match, tail, out newPath))
+                            if (TryRelocateWithin(parent!, name, match, isMsix, tail, out newPath))
                                 return true;
                         }
                     }
@@ -103,33 +124,55 @@ namespace pylorak.TinyWall
             return false;
         }
 
-        private static bool TryRelocateWithin(string parent, string originalName, Match originalMatch, string tail, out string newPath)
+        private static bool TryRelocateWithin(string parent, string originalName, Match originalMatch, bool isMsix, string tail, out string newPath)
         {
             newPath = string.Empty;
 
-            string stem = originalMatch.Groups["stem"].Value;
-            string searchPattern = (stem.Length > 0) ? stem + "*" : "*";
+            // Narrow the enumeration to the family the original folder belongs to. For a package
+            // that is the invariant part before the version; for the generic layout, the stem.
+            string stem = isMsix ? string.Empty : originalMatch.Groups["stem"].Value;
+            string searchPattern = isMsix
+                ? originalMatch.Groups["name"].Value + "_*"
+                : ((stem.Length > 0) ? stem + "*" : "*");
 
             IReadOnlyList<int>? bestVersion = null;
             DateTime bestWriteTime = DateTime.MinValue;
-            int scanned = 0;
 
-            foreach (string sibling in Directory.EnumerateDirectories(parent, searchPattern))
+            foreach (string sibling in EnumerateDirectoriesOrNone(parent, searchPattern))
             {
-                if (++scanned > MaxSiblingsScanned)
-                    break;
-
                 string siblingName = Path.GetFileName(sibling);
                 if (string.Equals(siblingName, originalName, StringComparison.OrdinalIgnoreCase))
                     continue;
 
-                var match = VersionedFolderRegex.Match(siblingName);
-                if (!match.Success)
-                    continue;
+                Match match;
+                if (isMsix)
+                {
+                    match = MsixPackageFolderRegex.Match(siblingName);
+                    if (!match.Success)
+                        continue;
 
-                // Only the version token may differ from the original directory name.
-                if (!string.Equals(match.Groups["stem"].Value, stem, StringComparison.OrdinalIgnoreCase))
-                    continue;
+                    // Same package, same architecture, same publisher - only the version may
+                    // differ. A package identity that differs in any other field is a different
+                    // application as far as Windows is concerned, so it is never followed.
+                    if (!IsSameMsixIdentity(originalMatch, match))
+                        continue;
+                }
+                else
+                {
+                    // Keep the two rules disjoint: a packaged folder is the MSIX rule's business
+                    // even when its publisher id happens to be all digits, which would otherwise
+                    // let the generic pattern match it as well.
+                    if (MsixPackageFolderRegex.IsMatch(siblingName))
+                        continue;
+
+                    match = VersionedFolderRegex.Match(siblingName);
+                    if (!match.Success)
+                        continue;
+
+                    // Only the version token may differ from the original directory name.
+                    if (!string.Equals(match.Groups["stem"].Value, stem, StringComparison.OrdinalIgnoreCase))
+                        continue;
+                }
 
                 // The path below the versioned directory must be reproduced exactly.
                 string candidate = Path.Combine(sibling, tail);
@@ -161,6 +204,47 @@ namespace pylorak.TinyWall
             }
 
             return newPath.Length > 0;
+        }
+
+        private static bool IsSameMsixIdentity(Match left, Match right)
+        {
+            return string.Equals(left.Groups["name"].Value, right.Groups["name"].Value, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(left.Groups["arch"].Value, right.Groups["arch"].Value, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(left.Groups["pub"].Value, right.Groups["pub"].Value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Lists sibling directories, treating an unreadable parent as simply having none.
+        ///
+        /// Directory.EnumerateDirectories is lazy, so a directory that denies listing - as
+        /// C:\Program Files\WindowsApps does, being ACL'd to TrustedInstaller - throws while the
+        /// caller iterates rather than when the enumerator is created. Left unhandled that would
+        /// escape TryRelocateWithin and abort the whole upward walk, losing the levels above.
+        /// Materialising the names here confines the failure to the level that caused it.
+        /// </summary>
+        private static IReadOnlyList<string> EnumerateDirectoriesOrNone(string parent, string searchPattern)
+        {
+            var ret = new List<string>();
+            try
+            {
+                foreach (string dir in Directory.EnumerateDirectories(parent, searchPattern))
+                {
+                    if (ret.Count >= MaxSiblingsScanned)
+                        break;
+                    ret.Add(dir);
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Deliberately discards whatever was collected before the failure, so that the
+                // outcome does not depend on how far the enumeration happened to get.
+                return Array.Empty<string>();
+            }
+            catch (IOException)
+            {
+                return Array.Empty<string>();
+            }
+            return ret;
         }
 
         private static IReadOnlyList<int> ParseVersion(string version)

--- a/TinyWall/ExecutableRelocator.cs
+++ b/TinyWall/ExecutableRelocator.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace pylorak.TinyWall
+{
+    /// <summary>
+    /// Recovers application exceptions that were invalidated by an application update.
+    ///
+    /// Squirrel/Electron-style installers (Claude, Discord, Slack, GitHub Desktop, ...) place every
+    /// release into its own versioned directory beside the previous one, for example:
+    ///     %LOCALAPPDATA%\AnthropicClaude\app-0.9.3\claude.exe
+    ///     %LOCALAPPDATA%\AnthropicClaude\app-0.11.0\claude.exe
+    /// WFP matches executables on their exact path (FWPM_CONDITION_ALE_APP_ID), so each update
+    /// silently invalidates the user's exception and the application loses network access until
+    /// the user notices and re-whitelists it by hand. Such applications update frequently, which
+    /// makes this a recurring annoyance rather than a one-off.
+    ///
+    /// This helper detects that specific situation and nothing else. The replacement must live in a
+    /// *sibling* directory of the original one whose name differs from it only in a version token,
+    /// and the path below that directory - including the file name - must be identical. The trust
+    /// boundary is therefore unchanged: anyone able to plant a file that this code would relocate to
+    /// already has write access to the directory holding the originally whitelisted executable, and
+    /// could simply have overwritten that file in place.
+    /// </summary>
+    internal static class ExecutableRelocator
+    {
+        // Matches directory names that carry a version token, capturing the part before it.
+        //   "app-0.11.0"   -> stem "app",      version "0.11.0"
+        //   "app-1.2.3-beta.1" -> stem "app",  version "1.2.3", suffix "-beta.1"
+        //   "2.14.0"       -> stem "",         version "2.14.0"
+        private static readonly Regex VersionedFolderRegex = new(
+            @"^(?<stem>.*?)[-_. ]?v?(?<version>\d+(?:\.\d+)*)(?<suffix>[-+][0-9A-Za-z.]+)?$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+        // How many directory levels above the executable may be the versioned one.
+        // Covers layouts like "app-1.2.3\resources\bin\helper.exe".
+        private const int MaxWalkDepth = 5;
+
+        // Upper bound on sibling directories inspected, so that a pathological directory
+        // cannot turn the periodic check into a long scan.
+        private const int MaxSiblingsScanned = 512;
+
+        /// <summary>
+        /// Tries to locate <paramref name="oldPath"/> in a newer sibling version directory.
+        /// Returns false - leaving <paramref name="newPath"/> empty - when no unambiguous,
+        /// tightly-matching replacement exists.
+        /// </summary>
+        public static bool TryFindRelocatedPath(string oldPath, out string newPath)
+        {
+            newPath = string.Empty;
+
+            if (Utils.IsNullOrEmpty(oldPath))
+                return false;
+
+            try
+            {
+                // Only ever act on a path that is actually gone.
+                if (File.Exists(oldPath))
+                    return false;
+
+                // Network and removable locations can be "missing" merely because they are
+                // offline. Relocating those would be guesswork, so leave them alone.
+                if (pylorak.Windows.NetworkPath.IsNetworkPath(oldPath))
+                    return false;
+
+                string? dir = Path.GetDirectoryName(oldPath);
+                string tail = Path.GetFileName(oldPath);
+                if (Utils.IsNullOrEmpty(tail))
+                    return false;
+
+                // Walk upwards from the executable, trying the deepest versioned directory first.
+                for (int depth = 0; (dir is not null) && (depth < MaxWalkDepth); ++depth)
+                {
+                    string name = Path.GetFileName(dir);
+                    string? parent = Path.GetDirectoryName(dir);
+
+                    if (!Utils.IsNullOrEmpty(name) && (parent is not null))
+                    {
+                        var match = VersionedFolderRegex.Match(name);
+
+                        // The parent must still exist. If it does not, we are not looking at an
+                        // updated application but at a detached drive or a deleted install root.
+                        if (match.Success && Directory.Exists(parent))
+                        {
+                            if (TryRelocateWithin(parent!, name, match, tail, out newPath))
+                                return true;
+                        }
+                    }
+
+                    tail = Path.Combine(name, tail);
+                    dir = parent;
+                }
+            }
+            catch (Exception e)
+            {
+                // Never let a filesystem hiccup take down the caller; a missed relocation
+                // just means the user re-whitelists by hand, as before.
+                Utils.LogException(e, Utils.LOG_ID_SERVICE);
+            }
+
+            return false;
+        }
+
+        private static bool TryRelocateWithin(string parent, string originalName, Match originalMatch, string tail, out string newPath)
+        {
+            newPath = string.Empty;
+
+            string stem = originalMatch.Groups["stem"].Value;
+            string searchPattern = (stem.Length > 0) ? stem + "*" : "*";
+
+            IReadOnlyList<int>? bestVersion = null;
+            DateTime bestWriteTime = DateTime.MinValue;
+            int scanned = 0;
+
+            foreach (string sibling in Directory.EnumerateDirectories(parent, searchPattern))
+            {
+                if (++scanned > MaxSiblingsScanned)
+                    break;
+
+                string siblingName = Path.GetFileName(sibling);
+                if (string.Equals(siblingName, originalName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var match = VersionedFolderRegex.Match(siblingName);
+                if (!match.Success)
+                    continue;
+
+                // Only the version token may differ from the original directory name.
+                if (!string.Equals(match.Groups["stem"].Value, stem, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // The path below the versioned directory must be reproduced exactly.
+                string candidate = Path.Combine(sibling, tail);
+                if (!File.Exists(candidate))
+                    continue;
+
+                var version = ParseVersion(match.Groups["version"].Value);
+                DateTime writeTime;
+                try { writeTime = File.GetLastWriteTimeUtc(candidate); }
+                catch { writeTime = DateTime.MinValue; }
+
+                // Highest version wins; equal versions are broken by the newer file.
+                if (bestVersion is null)
+                {
+                    bestVersion = version;
+                    bestWriteTime = writeTime;
+                    newPath = candidate;
+                }
+                else
+                {
+                    int cmp = CompareVersions(version, bestVersion);
+                    if ((cmp > 0) || ((cmp == 0) && (writeTime > bestWriteTime)))
+                    {
+                        bestVersion = version;
+                        bestWriteTime = writeTime;
+                        newPath = candidate;
+                    }
+                }
+            }
+
+            return newPath.Length > 0;
+        }
+
+        private static IReadOnlyList<int> ParseVersion(string version)
+        {
+            var parts = version.Split('.');
+            var ret = new int[parts.Length];
+            for (int i = 0; i < parts.Length; ++i)
+                ret[i] = int.TryParse(parts[i], out int val) ? val : 0;
+            return ret;
+        }
+
+        private static int CompareVersions(IReadOnlyList<int> left, IReadOnlyList<int> right)
+        {
+            int len = Math.Max(left.Count, right.Count);
+            for (int i = 0; i < len; ++i)
+            {
+                // Missing trailing components count as zero, so "1.2" == "1.2.0".
+                int l = (i < left.Count) ? left[i] : 0;
+                int r = (i < right.Count) ? right[i] : 0;
+                if (l != r)
+                    return l.CompareTo(r);
+            }
+            return 0;
+        }
+    }
+}

--- a/TinyWall/Program.cs
+++ b/TinyWall/Program.cs
@@ -106,6 +106,15 @@ namespace pylorak.TinyWall
                         }
                         return ExitCode.Success;
                     }
+                case StartupCommand.RelocationTest:
+                    {
+                        var cmdArgs = cliArgs.RelocationTest;
+                        // Exit code doubles as the result so the dry-run is scriptable:
+                        // Success when a replacement was found, GenericError when not.
+                        return DevelToolCli.TestRelocation(cmdArgs.ExecutablePath.Value!, cmdArgs.OutputFile.Value)
+                            ? ExitCode.Success
+                            : ExitCode.GenericError;
+                    }
                 default:
                     throw new InvalidOperationException();
             }
@@ -237,6 +246,7 @@ namespace pylorak.TinyWall
                 case StartupCommand.UpdateCreator:
                 case StartupCommand.ResXOptimizer:
                 case StartupCommand.BatchSigner:
+                case StartupCommand.RelocationTest:
                     AppDomain.CurrentDomain.UnhandledException += UnhandledException_Cli;
                     break;
                 default:

--- a/TinyWall/TinyWallService.cs
+++ b/TinyWall/TinyWallService.cs
@@ -1076,7 +1076,11 @@ namespace pylorak.TinyWall
             VisibleState.Mode = ActiveConfig.Service.StartupMode;
             GlobalInstances.ServerChangeset = Guid.NewGuid();
 
-            if (CommitLearnedRules() || PruneExpiredRules())
+            // Note: these must not short-circuit, each pass needs to run.
+            bool configChanged = CommitLearnedRules();
+            configChanged |= PruneExpiredRules();
+            configChanged |= RelocateUpdatedExecutables();
+            if (configChanged)
                 ActiveConfig.Service.Save(ConfigSavePath);
 
             ReapplySettings();
@@ -1308,6 +1312,47 @@ namespace pylorak.TinyWall
             return config_changed;
         }
 
+        // Applications that install every release into its own versioned directory
+        // (Squirrel/Electron installers, among others) leave the user's exception pointing at a
+        // path that no longer exists, silently losing network access on each update. Where the
+        // executable reappears in a sibling version directory under an otherwise identical path,
+        // follow it instead of making the user re-whitelist the application by hand.
+        private static bool RelocateUpdatedExecutables()
+        {
+            bool config_changed = false;
+
+            List<FirewallExceptionV3> exs = ActiveConfig.Service.ActiveProfile.AppExceptions;
+            for (int i = 0; i < exs.Count; ++i)
+            {
+                if (exs[i].Subject is not ExecutableSubject exe)
+                    continue;
+
+                ExecutableSubject resolved = exe.ToResolved();
+                if (File.Exists(resolved.ExecutablePath))
+                    continue;
+
+                if (!ExecutableRelocator.TryFindRelocatedPath(resolved.ExecutablePath, out string newPath))
+                    continue;
+
+                exs[i].Subject = resolved switch
+                {
+                    ServiceSubject srv => new ServiceSubject(newPath, srv.ServiceName),
+                    _ => new ExecutableSubject(newPath)
+                };
+
+                Utils.Log($"Application exception followed to updated location. Old path: '{resolved.ExecutablePath}'. New path: '{newPath}'.", Utils.LOG_ID_SERVICE);
+                config_changed = true;
+            }
+
+            if (config_changed)
+            {
+                GlobalInstances.ServerChangeset = Guid.NewGuid();
+                ActiveConfig.Service.ActiveProfile.AppExceptions = exs;
+            }
+
+            return config_changed;
+        }
+
         private TwMessage ProcessCmd(TwMessage req)
         {
             switch (req.Type)
@@ -1498,6 +1543,14 @@ namespace pylorak.TinyWall
                         }
 
                         if (PruneExpiredRules())
+                        {
+                            save_needed = true;
+                            rule_reload_needed = true;
+                        }
+
+                        // Applications that install each release into a new versioned folder
+                        // invalidate their own exception every time they update. Follow them.
+                        if (RelocateUpdatedExecutables())
                         {
                             save_needed = true;
                             rule_reload_needed = true;


### PR DESCRIPTION
The build workflow is currently dispatch-only: the `push` and `pull_request` triggers are
present but commented out, so nothing verifies a change before it lands. This enables them
exactly as they were written, restricted to `master`, and runs the relocation test script after
each matrix build.

```yaml
on:
  push:
    branches: [master]
  pull_request:
    branches: [master]
  workflow_dispatch:
```

## Stacked on #133 and #134

This one comes last of the three, and depends on both:

- **#133** adds `.github/scripts/test-relocation.ps1`, which the new step invokes.
- **#134** fixes MSI packaging. Without it, enabling `push` would turn CI **red on every commit
  to master**, because the staging step fails before the linker even runs.

Until those merge, the diff here shows their commits too. Once they land, this PR reduces to the
workflow change alone. If you would rather not enable the triggers at all, #133 and #134 both
stand on their own and this can simply be closed — the test script is standalone either way:

```
powershell -File .github/scripts/test-relocation.ps1 -Exe TinyWall\bin\Release\TinyWall.exe
```

## Validation

Dispatched on the full stack: four matrix jobs green, relocation tests 21/21 on both Debug and
Release, MSIs built and uploaded.

https://github.com/ChrisRosser/TinyWall/actions/runs/33752832547

🤖 Generated with [Claude Code](https://claude.com/claude-code)
