### PR TITLE
Warn when a picked Store app runs with full trust

### DIFF
--- a/TinyWall/Resources/Messages.Designer.cs
+++ b/TinyWall/Resources/Messages.Designer.cs
@@ -440,6 +440,15 @@ namespace pylorak.TinyWall.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} runs with full trust and is not a sandboxed app..
+        /// </summary>
+        internal static string FullTrustPackageWarning {
+            get {
+                return ResourceManager.GetString("FullTrustPackageWarning", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Permanent.
         /// </summary>
         internal static string Permanent {

--- a/TinyWall/Resources/Messages.resx
+++ b/TinyWall/Resources/Messages.resx
@@ -289,6 +289,12 @@ Select Elevate from the tray menu and try again.</value>
     <value>Unknown application</value>
     <comment>Exception details window banner text</comment>
   </data>
+  <data name="FullTrustPackageWarning" xml:space="preserve">
+    <value>{0} runs with full trust and is not a sandboxed app.
+An exception for a Store app is matched against an identity that only sandboxed apps have, so it will not apply to this application's network traffic. To control it, add its executable as an application exception instead.
+
+Do you still want to add the Store app exception?</value>
+  </data>
   <data name="Permanent" xml:space="preserve">
     <value>Permanent</value>
   </data>

--- a/TinyWall/TinyWall.csproj
+++ b/TinyWall/TinyWall.csproj
@@ -42,6 +42,7 @@
     <!-- Used for WinRT access in .Net 4.8, not needed with .NET 5+ -->
     <Reference Include="Windows.Management" />
     <Reference Include="Windows.ApplicationModel" />
+    <Reference Include="Windows.Storage" />
     <Reference Include="System.Runtime" />
 
   </ItemGroup>

--- a/TinyWall/UwpPackageList.cs
+++ b/TinyWall/UwpPackageList.cs
@@ -30,6 +30,7 @@ namespace pylorak.TinyWall
             public readonly string Name;
             public readonly string Publisher;
             public readonly string PublisherId;
+            public readonly string FamilyName;
             public readonly string Sid;
             public readonly TamperedState Tampered;
 
@@ -38,6 +39,7 @@ namespace pylorak.TinyWall
                 Name = p.Id.Name;
                 Publisher = p.Id.Publisher;
                 PublisherId = p.Id.PublisherId;
+                FamilyName = p.Id.FamilyName;
                 Tampered = p.Status.Tampered ? TamperedState.Yes : TamperedState.No;
 
                 SafeSidHandle? pSid = null;
@@ -130,6 +132,58 @@ namespace pylorak.TinyWall
             }
 
             return resultList;
+        }
+
+        public enum FullTrustState
+        {
+            Unknown,
+            No,
+            Yes
+        }
+
+        /// <summary>
+        /// Tells whether a package runs with full trust, i.e. is a packaged desktop application
+        /// rather than a sandboxed UWP app.
+        ///
+        /// This matters because an exception for a package is enforced through
+        /// FWPM_CONDITION_ALE_PACKAGE_ID, which is only present on the token of a process running
+        /// inside an AppContainer. A full trust package - Spotify, Arc, and by now a good number
+        /// of Microsoft's own apps - runs as an ordinary Win32 process with no such token, so a
+        /// package-based rule can never match its traffic. Note that the package SID itself gives
+        /// nothing away: DeriveAppContainerSidFromAppContainerName is a pure derivation from the
+        /// family name and succeeds whether or not the app is ever sandboxed.
+        ///
+        /// Returns Unknown when the manifest cannot be read, so that callers can stay silent
+        /// rather than warn on a guess.
+        /// </summary>
+        public static FullTrustState GetFullTrustState(string familyName)
+        {
+            try
+            {
+                var pm = new PackageManager();
+                foreach (var p in pm.FindPackagesForUser(string.Empty, familyName))
+                {
+                    string manifestPath = System.IO.Path.Combine(p.InstalledLocation.Path, "AppxManifest.xml");
+                    string manifest = System.IO.File.ReadAllText(manifestPath);
+
+                    // A packaged desktop application declares the runFullTrust restricted
+                    // capability, and its entry point is Windows.FullTrustApplication. Both
+                    // strings are specific enough to test for without parsing the manifest,
+                    // which would otherwise mean dealing with its several namespaces.
+                    bool fullTrust =
+                        (manifest.IndexOf("Windows.FullTrustApplication", StringComparison.OrdinalIgnoreCase) >= 0)
+                        || (manifest.IndexOf("Name=\"runFullTrust\"", StringComparison.OrdinalIgnoreCase) >= 0);
+
+                    return fullTrust ? FullTrustState.Yes : FullTrustState.No;
+                }
+            }
+            catch
+            {
+                // Deliberately swallowed: the manifest lives under %ProgramFiles%\WindowsApps,
+                // and not being able to read it is not a reason to fail the caller.
+            }
+
+            return FullTrustState.Unknown;
         }
 
         public Package? FindPackage(string? sid)

--- a/TinyWall/UwpPackagesForm.cs
+++ b/TinyWall/UwpPackagesForm.cs
@@ -1,9 +1,11 @@
 ﻿using DarkModeForms;
+using Microsoft.Samples.TaskDialog;
 using pylorak.Windows;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using System.Windows.Forms;
 
 namespace pylorak.TinyWall
@@ -43,10 +45,35 @@ namespace pylorak.TinyWall
 
         private void btnOK_Click(object sender, EventArgs e)
         {
+            var selection = new List<UwpPackageList.Package>();
             for (int i = 0; i < listView.SelectedItems.Count; ++i)
             {
-                this.SelectedPackages.Add((UwpPackageList.Package)listView.SelectedItems[i].Tag);
+                selection.Add((UwpPackageList.Package)listView.SelectedItems[i].Tag);
             }
+
+            // A rule for a package matches on the AppContainer token of its processes. Packaged
+            // desktop applications run with full trust and have no such token, so an exception
+            // for one would be accepted here and then silently never match anything. Say so
+            // instead, and point at the exception type that does work for them.
+            var fullTrust = new List<string>();
+            foreach (var package in selection)
+            {
+                if (UwpPackageList.GetFullTrustState(package.FamilyName) == UwpPackageList.FullTrustState.Yes)
+                    fullTrust.Add(package.Name);
+            }
+
+            if (fullTrust.Count > 0)
+            {
+                string prompt = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resources.Messages.FullTrustPackageWarning,
+                    string.Join(", ", fullTrust.ToArray()));
+
+                if (Utils.ShowMessageBox(prompt, Resources.Messages.TinyWall, TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No, TaskDialogIcon.Warning, this) != System.Windows.Forms.DialogResult.Yes)
+                    return;
+            }
+
+            this.SelectedPackages.AddRange(selection);
             this.DialogResult = System.Windows.Forms.DialogResult.OK;
         }
 


### PR DESCRIPTION
Closes half of #59 — the "Pick a UWP app..." button appearing not to work. Your hunch in that
thread was right: these are not UWP apps at all.

## Diagnosis

An exception for a Store app becomes a rule keyed solely on the package SID
(`RuleDef` sets `Application = null` and `AppContainerSid = uwp.Sid`), enforced through
`FWPM_CONDITION_ALE_PACKAGE_ID`. That condition is only present on the token of a process
running **inside an AppContainer**. A packaged desktop application runs as an ordinary Win32
process with no such token, so the rule can never match its traffic.

Nothing signals this today, because neither of the two things the picker relies on can tell the
kinds apart:

- `FindPackagesForUser` returns every installed package, sandboxed or not.
- `DeriveAppContainerSidFromAppContainerName` is a pure derivation from the family name. It
  succeeds whether or not the app is ever sandboxed, so a perfectly plausible SID comes back
  for an app that will never have one.

The exception is therefore accepted and then silently never matches — which reads to the user
as the picker simply not working.

## Evidence

Checked on Windows 11 26200 by reading each package manifest and, separately, querying
`TokenIsAppContainer` on the live process. The two agree exactly:

| Package | Manifest | `TokenIsAppContainer` |
|---|---|---|
| `Claude` | `runFullTrust` + `Windows.FullTrustApplication` | no |
| `SpotifyAB.SpotifyMusic` | `runFullTrust` + `Windows.FullTrustApplication` | no |
| `Microsoft.WindowsTerminal` | `runFullTrust` + `Windows.FullTrustApplication` | no |
| `Microsoft.WindowsNotepad` | `runFullTrust` + `Windows.FullTrustApplication` | no |
| `Microsoft.ZuneVideo` | neither | **yes** |
| `Microsoft.WindowsCalculator` | neither | **yes** |

Worth noting how far this now reaches: Notepad, Paint, Photos, Terminal and the Store itself are
all full trust these days, so this is not limited to third-party apps.

## Change

Detect full trust from the package manifest and warn on selection, pointing at the application
exception that does work for these. Deliberately conservative:

- The warning is raised **only on a positive determination**. An unreadable manifest yields
  `Unknown` and stays silent, so nothing changes for packages we cannot classify.
- The user can still proceed. A package may carry both kinds of application — Spotify ships
  three full-trust entries plus a genuine UWP Game Bar widget — so blocking outright would be
  wrong.
- Detection is lazy, run only for the packages actually selected, so opening the picker does not
  get slower.

The manifest is read rather than XML-parsed, since `runFullTrust` and
`Windows.FullTrustApplication` are specific enough to test for without dealing with the
manifest's several namespaces. `%ProgramFiles%\WindowsApps` denies directory *listing* to normal
users but permits reading a known file, which is what this does.

`Windows.Storage` is added to the project references because `Package.InstalledLocation` returns
a `StorageFolder`; without it the file does not compile.

## Testing

Built green in all four matrix configurations. The Release jobs fail at `Stage files for MSI`,
which is the pre-existing packaging bug from #134 and unrelated to this change — the `Build`
step itself passes everywhere.

https://github.com/ChrisRosser/TinyWall/actions/runs/33758820811

To be straight about the limits: I verified the detection logic against real packages on a live
system as above, but I could not exercise the dialog itself in an automated way, so the wording
and flow of the warning are worth a look. The new string is added to the neutral
`Messages.resx` only, so the other 17 locales fall back to English until translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
